### PR TITLE
Avoid crash on spring boot jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.viktorc</groupId>
 	<artifactId>pp4j</artifactId>
-	<version>2.1</version>
+	<version>2.2</version>
 	<name>PP4J</name>
 	<description>A multiprocessing library for Java.</description>
 	<url>https://github.com/ViktorC/PP4J</url>

--- a/src/main/java/net/viktorc/pp4j/impl/JavaProcessPoolExecutor.java
+++ b/src/main/java/net/viktorc/pp4j/impl/JavaProcessPoolExecutor.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -288,6 +289,8 @@ public class JavaProcessPoolExecutor extends ProcessPoolExecutor implements Java
 				for (URL url : urlClassLoader.getURLs()) {
 					try {
 						classPathEntries.add(Paths.get(url.toURI()).toAbsolutePath().toString());
+					} catch (FileSystemNotFoundException e){
+						continue;
 					} catch (URISyntaxException e) {
 						continue;
 					}


### PR DESCRIPTION
When a URL like _jar:file:/xx.jar!/BOOT-INF/classes!_ enters in Paths.get() an uncontrolled runtime exception _FileSystemNotFoundException_ is launched.

This happens using the library in a spring boot based project with jar packaging.

Regards
